### PR TITLE
make checkstyle config compatible with 6.2+ of checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 target
+.idea
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>11</version>
+      <version>18</version>
     </parent>
 
     <groupId>io.undertow.build</groupId>
     <artifactId>undertow-checkstyle-config</artifactId>
     <name>Undertow Checkstyle Configuration</name>
-    <version>1.0.0.Final</version>
+    <version>1.0.1.Final-SNAPSHOT</version>
     <description>The checkstyle config for the Undertow build</description>
 
 </project>

--- a/src/main/resources/undertow-checkstyle/checkstyle.xml
+++ b/src/main/resources/undertow-checkstyle/checkstyle.xml
@@ -61,9 +61,6 @@
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-        </module>
 
         <!-- Miscellaneous other checks.                   -->
         <module name="UpperEll"/>


### PR DESCRIPTION
Required to use checkstyle that also supports JDK8 syntax
